### PR TITLE
Fix typo in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "prefligit"
 version = "0.0.8"
 authors = ["j178 <hi@j178.dev>"]
-description = "pre-commit implemeneted in Rust"
+description = "pre-commit implemented in Rust"
 repository = "https://github.com/j178/prefligit"
 homepage = "https://github.com/j178/prefligit"
 edition = "2021"


### PR DESCRIPTION
Noticed this at https://docs.rs/releases:

<img width="1182" alt="image" src="https://github.com/user-attachments/assets/2043d723-4ab6-43fa-b32c-7bc653832a56" />
