### PR TITLE
Restructure folders layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,15 +257,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "bstr"
 version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,16 +438,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "ctrlc"
 version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,16 +461,6 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
-]
 
 [[package]]
 name = "displaydoc"
@@ -580,18 +551,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
-name = "fallible-streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
 name = "fancy-regex"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,12 +595,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foldhash"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,6 +610,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f89bda4c2a21204059a977ed3bfe746677dfd137b83c339e702b0ac91d482aa"
 dependencies = [
  "autocfg",
+ "tokio",
 ]
 
 [[package]]
@@ -759,16 +713,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,18 +772,6 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashlink"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
-dependencies = [
- "hashbrown",
-]
 
 [[package]]
 name = "heck"
@@ -852,6 +784,12 @@ name = "hermit-abi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "home"
@@ -1276,17 +1214,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
-name = "libsqlite3-sys"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8935b44e7c13394a179a438e0cebba0fe08fe01b54f152e29a93b5cf993fd4"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1327,16 +1254,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
-]
-
-[[package]]
-name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest",
 ]
 
 [[package]]
@@ -1562,12 +1479,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
-
-[[package]]
 name = "portable-atomic"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1654,6 +1565,7 @@ dependencies = [
  "fs-err",
  "fs2",
  "futures",
+ "hex",
  "http",
  "indicatif",
  "indoc",
@@ -1661,7 +1573,6 @@ dependencies = [
  "insta-cmd",
  "itertools",
  "libc",
- "md-5",
  "miette",
  "owo-colors",
  "pprof",
@@ -1670,8 +1581,8 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest",
- "rusqlite",
  "same-file",
+ "seahash",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1967,20 +1878,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusqlite"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c6d5e5acb6f6129fe3f7ba0a7fc77bca1942cb568535e18e7bc40262baf3110"
-dependencies = [
- "bitflags 2.8.0",
- "fallible-iterator",
- "fallible-streaming-iterator",
- "hashlink",
- "libsqlite3-sys",
- "smallvec",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2074,6 +1971,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "self-replace"
@@ -2558,12 +2461,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "typenum"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2640,12 +2537,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,21 +39,21 @@ ctrlc = "3.4.5"
 dunce = "1.0.5"
 etcetera = "0.8.0"
 fancy-regex = "0.14.0"
-fs-err = "3.1.0"
+fs-err = { version = "3.1.0", features = ["tokio"] }
 fs2 = "0.4.3"
 futures = "0.3.31"
+hex = "0.4.3"
 http = "1.1.0"
 indicatif = "0.17.8"
 indoc = "2.0.5"
 itertools = "0.14.0"
-md-5 = "0.10.6"
 miette = { version = "7.5.0", features = ["fancy-no-backtrace"] }
 owo-colors = "4.1.0"
 rand = "0.9.0"
 rayon = "1.10.0"
 reqwest = { version = "0.12.9", default-features = false }
-rusqlite = { version = "0.33.0", features = ["bundled"] }
 same-file = "1.0.6"
+seahash = "4.1.0"
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.132"
 serde_yaml = "0.9.34"

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
+use std::hash::Hash;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::Mutex;
@@ -37,7 +38,7 @@ pub enum Error {
 #[derive(Debug, Clone)]
 pub enum Repo {
     Remote {
-        /// Path to the stored repo.
+        /// Path to the cloned repo.
         path: PathBuf,
         url: Url,
         rev: String,
@@ -53,17 +54,14 @@ pub enum Repo {
 
 impl Repo {
     /// Load the remote repo manifest from the path.
-    pub fn remote(url: &str, rev: &str, path: &str) -> Result<Self, Error> {
-        let url = Url::parse(url)?;
-
-        let path = PathBuf::from(path);
+    pub fn remote(url: Url, rev: String, path: PathBuf) -> Result<Self, Error> {
         let manifest = read_manifest(&path.join(MANIFEST_FILE))?;
         let hooks = manifest.hooks;
 
         Ok(Self::Remote {
             path,
             url,
-            rev: rev.to_string(),
+            rev,
             hooks,
         })
     }
@@ -80,6 +78,14 @@ impl Repo {
         }
     }
 
+    /// Get the path to the cloned repo if it is a remote repo.
+    pub fn path(&self) -> Option<&Path> {
+        match self {
+            Repo::Remote { ref path, .. } => Some(path),
+            _ => None,
+        }
+    }
+
     /// Get a hook by id.
     pub fn get_hook(&self, id: &str) -> Option<&ManifestHook> {
         let hooks = match self {
@@ -88,15 +94,6 @@ impl Repo {
             Repo::Meta { ref hooks } => hooks,
         };
         hooks.iter().find(|hook| hook.id == id)
-    }
-
-    /// Get the path to the repo.
-    pub fn path(&self) -> &Path {
-        match self {
-            Repo::Remote { ref path, .. } => path,
-            Repo::Local { .. } => &CWD,
-            Repo::Meta { .. } => &CWD,
-        }
     }
 }
 
@@ -178,19 +175,16 @@ impl Project {
                         (reporter, reporter.on_clone_start(&format!("{repo_config}")))
                     });
 
-                    let path = store
-                        .prepare_remote_repo(repo_config, &[])
-                        .await
-                        .map_err(Box::new)?;
+                    let path = store.clone_repo(repo_config).await.map_err(Box::new)?;
 
                     if let Some((reporter, progress)) = progress {
                         reporter.on_clone_complete(progress);
                     }
 
                     let repo = Rc::new(Repo::remote(
-                        repo_config.repo.as_str(),
-                        &repo_config.rev,
-                        &path.to_string_lossy(),
+                        repo_config.repo.clone(),
+                        repo_config.rev.clone(),
+                        path,
                     )?);
                     remote_repos
                         .lock()
@@ -256,22 +250,9 @@ impl Project {
                         let mut builder = HookBuilder::new(repo, hook.clone());
                         builder.update(hook_config);
                         builder.combine(&self.config);
+
                         let mut hook = builder.build();
-
-                        if hook.additional_dependencies.is_empty() {
-                            // Use the shared repo environment.
-                            let path = hook.repo.path().to_path_buf();
-                            hook = hook.with_path(path);
-                        } else {
-                            // Prepare hooks with `additional_dependencies` (they need separate environments).
-                            let path = store
-                                .prepare_remote_repo(repo_config, &hook.additional_dependencies)
-                                .await
-                                .map_err(Box::new)?;
-
-                            hook = hook.with_path(path);
-                        }
-
+                        hook.with_path(store.hook_path(&hook));
                         hooks.push(hook);
                     }
                 }
@@ -280,20 +261,9 @@ impl Project {
                         let repo = Rc::clone(repo);
                         let mut builder = HookBuilder::new(repo, hook_config.clone());
                         builder.combine(&self.config);
+
                         let mut hook = builder.build();
-
-                        // If the hook doesn't need an environment, don't do any preparation.
-                        if hook.language.environment_dir().is_some() {
-                            let path = store
-                                .prepare_local_repo(&hook, &hook.additional_dependencies)
-                                .map_err(Box::new)?;
-
-                            hook = hook.with_path(path);
-                        } else {
-                            // Use the shared repo environment.
-                            let path = hook.repo.path().to_path_buf();
-                            hook = hook.with_path(path);
-                        }
+                        hook.with_path(store.hook_path(&hook));
                         hooks.push(hook);
                     }
                 }
@@ -303,10 +273,9 @@ impl Project {
                         let hook_config = ManifestHook::from(hook_config.clone());
                         let mut builder = HookBuilder::new(repo, hook_config);
                         builder.combine(&self.config);
-                        let mut hook = builder.build();
 
-                        let path = hook.repo.path().to_path_buf();
-                        hook = hook.with_path(path);
+                        let mut hook = builder.build();
+                        hook.with_path(store.hook_path(&hook));
                         hooks.push(hook);
                     }
                 }
@@ -392,7 +361,7 @@ impl HookBuilder {
     fn check(&self) {
         let language = self.config.language;
         let options = &self.config.options;
-        if language.environment_dir().is_none() {
+        if !language.supports_dependency() {
             if options.additional_dependencies.is_some() {
                 warn_user!(
                     "Language {} does not need environment, but additional_dependencies is set",
@@ -405,7 +374,7 @@ impl HookBuilder {
             .as_ref()
             .is_some_and(|v| !v.is_default())
         {
-            if language.environment_dir().is_none() {
+            if !language.supports_dependency() {
                 warn_user!(
                     "Language {} does not need environment, but language_version is set",
                     language
@@ -489,17 +458,7 @@ pub struct Hook {
 impl Display for Hook {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if f.alternate() {
-            if let Some(ref path) = self.path {
-                write!(
-                    f,
-                    "{} ({} at {})",
-                    self.id,
-                    self.repo,
-                    path.to_string_lossy()
-                )
-            } else {
-                write!(f, "{} ({})", self.id, self.repo)
-            }
+            write!(f, "{} ({})", self.id, self.repo)
         } else {
             write!(f, "{}", self.id)
         }
@@ -507,49 +466,72 @@ impl Display for Hook {
 }
 
 impl Hook {
-    pub fn with_path(mut self, path: PathBuf) -> Self {
-        self.path = Some(path);
-        self
+    fn with_path(&mut self, path: Option<PathBuf>) {
+        self.path = path;
     }
 
     pub fn repo(&self) -> &Repo {
         &self.repo
     }
 
-    /// Get the working directory for the hook.
-    pub fn path(&self) -> &Path {
-        self.path.as_deref().unwrap_or_else(|| self.repo.path())
+    /// Get the path to the repository that contains the hook.
+    pub fn repo_path(&self) -> Option<&Path> {
+        self.repo.path()
     }
 
-    /// Get the environment directory that the hook will be installed to.
-    pub fn environment_dir(&self) -> Option<PathBuf> {
-        let env_dir = self.language.environment_dir()?;
-        Some(
-            self.path()
-                .join(format!("{}-{}", env_dir, &self.language_version)),
-        )
+    /// Get the path to the environment directory (where the hook is installed) if it exists.
+    pub fn env_path(&self) -> Option<&Path> {
+        self.path.as_deref()
+    }
+
+    pub fn is_local(&self) -> bool {
+        matches!(&*self.repo, Repo::Local { .. })
+    }
+
+    pub fn is_remote(&self) -> bool {
+        matches!(&*self.repo, Repo::Remote { .. })
+    }
+
+    pub fn is_meta(&self) -> bool {
+        matches!(&*self.repo, Repo::Meta { .. })
     }
 
     // TODO: health check
+
     /// Check if the hook is installed in the environment.
     pub fn installed(&self) -> bool {
-        let Some(env) = self.environment_dir() else {
+        let Some(env) = self.env_path() else {
             return true;
         };
-
-        let state_file_v2 = env.join(".install_state_v2");
-        state_file_v2.exists()
-        // Drop support for state file v1.
+        env.join(".installed_ok").exists()
     }
 
     /// Write a state file to mark the hook as installed.
-    pub fn mark_installed(&self) -> Result<(), Error> {
-        let env = self.environment_dir().unwrap();
-        let state_file_v2 = env.join(".install_state_v2");
-        fs_err::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .open(&state_file_v2)?;
+    pub fn mark_as_installed(&self) -> Result<(), Error> {
+        let Some(env) = self.env_path() else {
+            return Ok(());
+        };
+        fs_err::write(env.join(".installed_ok"), "")?;
+        fs_err::write(env.join(".repo_source"), self.repo.to_string())?;
         Ok(())
+    }
+}
+
+impl Hash for Hook {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match &*self.repo {
+            Repo::Remote { url, rev, .. } => {
+                url.hash(state);
+                rev.hash(state);
+            }
+            Repo::Local { .. } => {
+                "local".hash(state);
+            }
+            Repo::Meta { .. } => unreachable!(),
+        }
+
+        self.language.as_str().hash(state);
+        self.language_version.as_str().hash(state);
+        self.additional_dependencies.hash(state);
     }
 }

--- a/src/languages/docker_image.rs
+++ b/src/languages/docker_image.rs
@@ -10,8 +10,8 @@ use crate::run::run_by_batch;
 pub struct DockerImage;
 
 impl LanguageImpl for DockerImage {
-    fn environment_dir(&self) -> Option<&str> {
-        None
+    fn supports_dependency(&self) -> bool {
+        false
     }
 
     async fn install(&self, _: &Hook) -> anyhow::Result<()> {

--- a/src/languages/fail.rs
+++ b/src/languages/fail.rs
@@ -7,8 +7,8 @@ use crate::languages::LanguageImpl;
 pub struct Fail;
 
 impl LanguageImpl for Fail {
-    fn environment_dir(&self) -> Option<&str> {
-        None
+    fn supports_dependency(&self) -> bool {
+        false
     }
 
     async fn install(&self, _hook: &Hook) -> anyhow::Result<()> {

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -22,7 +22,11 @@ static DOCKER: docker::Docker = docker::Docker;
 static DOCKER_IMAGE: docker_image::DockerImage = docker_image::DockerImage;
 
 trait LanguageImpl {
-    fn environment_dir(&self) -> Option<&str>;
+    /// Whether the language supports installing dependencies.
+    ///
+    /// For example, Python and Node.js support installing dependencies, while
+    /// System and Fail do not.
+    fn supports_dependency(&self) -> bool;
     async fn install(&self, hook: &Hook) -> Result<()>;
     async fn check_health(&self) -> Result<()>;
     async fn run(
@@ -34,14 +38,14 @@ trait LanguageImpl {
 }
 
 impl Language {
-    pub fn environment_dir(&self) -> Option<&str> {
+    pub fn supports_dependency(self) -> bool {
         match self {
-            Self::Python => PYTHON.environment_dir(),
-            Self::Node => NODE.environment_dir(),
-            Self::System => SYSTEM.environment_dir(),
-            Self::Fail => FAIL.environment_dir(),
-            Self::Docker => DOCKER.environment_dir(),
-            Self::DockerImage => DOCKER_IMAGE.environment_dir(),
+            Self::Python => PYTHON.supports_dependency(),
+            Self::Node => NODE.supports_dependency(),
+            Self::System => SYSTEM.supports_dependency(),
+            Self::Fail => FAIL.supports_dependency(),
+            Self::Docker => DOCKER.supports_dependency(),
+            Self::DockerImage => DOCKER_IMAGE.supports_dependency(),
             _ => todo!(),
         }
     }

--- a/src/languages/node.rs
+++ b/src/languages/node.rs
@@ -8,15 +8,17 @@ use crate::languages::LanguageImpl;
 pub struct Node;
 
 impl LanguageImpl for Node {
-    fn environment_dir(&self) -> Option<&str> {
-        Some("node_env")
+    fn supports_dependency(&self) -> bool {
+        true
     }
 
     async fn install(&self, hook: &Hook) -> anyhow::Result<()> {
         // TODO: install node automatically
-        let env = hook.environment_dir().expect("No environment dir found");
-        fs_err::create_dir_all(env)?;
+        let Some(env) = hook.env_path() else {
+            return Ok(());
+        };
 
+        fs_err::create_dir_all(env)?;
         Ok(())
     }
 

--- a/src/languages/system.rs
+++ b/src/languages/system.rs
@@ -10,8 +10,8 @@ use crate::run::run_by_batch;
 pub struct System;
 
 impl LanguageImpl for System {
-    fn environment_dir(&self) -> Option<&str> {
-        None
+    fn supports_dependency(&self) -> bool {
+        false
     }
 
     async fn install(&self, _hook: &Hook) -> anyhow::Result<()> {

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,18 +1,19 @@
+use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
 use anyhow::Result;
 use etcetera::BaseStrategy;
-use rusqlite::Connection;
+use seahash::SeaHasher;
 use thiserror::Error;
 use tracing::debug;
 
 use constants::env_vars::EnvVars;
 
 use crate::config::RemoteRepo;
-use crate::fs::{copy_dir_all, LockedFile};
+use crate::fs::LockedFile;
 use crate::git::clone_repo;
-use crate::hook::{Hook, Repo};
+use crate::hook::Hook;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -24,8 +25,6 @@ pub enum Error {
     Io(#[from] std::io::Error),
     #[error(transparent)]
     Fmt(#[from] std::fmt::Error),
-    #[error(transparent)]
-    DB(#[from] rusqlite::Error),
     #[error(transparent)]
     Repo(#[from] crate::hook::Error),
     #[error(transparent)]
@@ -50,7 +49,6 @@ static STORE_HOME: LazyLock<Option<PathBuf>> = LazyLock::new(|| {
 #[derive(Debug)]
 pub struct Store {
     path: PathBuf,
-    conn: Option<Connection>,
 }
 
 impl Store {
@@ -61,203 +59,46 @@ impl Store {
     }
 
     pub fn from_path(path: impl Into<PathBuf>) -> Self {
-        Self {
-            path: path.into(),
-            conn: None,
-        }
+        Self { path: path.into() }
     }
 
     pub fn path(&self) -> &Path {
         self.path.as_ref()
     }
 
-    fn conn(&self) -> &Connection {
-        self.conn.as_ref().expect("store not initialized")
-    }
-
     /// Initialize the store.
     pub fn init(self) -> Result<Self, Error> {
         fs_err::create_dir_all(&self.path)?;
-
-        // Write a README file.
-        match fs_err::write(
-            self.path.join("README"),
-            b"This directory is maintained by the pre-commit project.\nLearn more: https://github.com/pre-commit/pre-commit\n",
-        ) {
-            Ok(()) => (),
-            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => (),
-            Err(err) => return Err(err.into()),
-        }
-
-        let _lock = self.lock()?;
-
-        // Init the database.
-        let db = self.path.join("db.db");
-        let conn = if db.try_exists()? {
-            debug!(db = %db.display(), "Opening database");
-            Connection::open(&db)?
-        } else {
-            debug!(db = %db.display(), "Creating database");
-            let conn = Connection::open(&db)?;
-            conn.execute(
-                "CREATE TABLE repos (
-                    repo TEXT NOT NULL,
-                    ref TEXT NOT NULL,
-                    path TEXT NOT NULL,
-                    PRIMARY KEY (repo, ref)
-                );",
-                [],
-            )?;
-            conn
-        };
-
-        Ok(Self {
-            conn: Some(conn),
-            ..self
-        })
-    }
-
-    /// List all repos.
-    pub fn repos(&self) -> Result<Vec<Repo>, Error> {
-        let mut stmt = self.conn().prepare("SELECT repo, ref, path FROM repos")?;
-
-        let rows: Vec<_> = stmt
-            .query_map([], |row| {
-                let name: String = row.get(0)?;
-                let rev: String = row.get(1)?;
-                let path: String = row.get(2)?;
-                Ok((name, rev, path))
-            })?
-            .collect::<Result<_, _>>()?;
-
-        // TODO: fix, local repo can also in the store
-        rows.into_iter()
-            .map(|(url, rev, path)| Repo::remote(&url, &rev, &path).map_err(Error::Repo))
-            .collect::<Result<Vec<_>, Error>>()
-    }
-
-    // Append dependencies to the repo name as the key.
-    fn repo_name(repo: &str, deps: &[String]) -> String {
-        let mut name = repo.to_string();
-        if !deps.is_empty() {
-            name.push(':');
-            name.push_str(&deps.join(","));
-        }
-        name
-    }
-
-    fn get_repo(
-        &self,
-        repo: &str,
-        rev: &str,
-        deps: &[String],
-    ) -> Result<Option<(String, String, String)>, Error> {
-        let repo_name = Self::repo_name(repo, deps);
-
-        let mut stmt = self
-            .conn()
-            .prepare("SELECT repo, ref, path FROM repos WHERE repo = ? AND ref = ?")?;
-        let mut rows = stmt.query([repo_name.as_str(), rev])?;
-        let Some(row) = rows.next()? else {
-            return Ok(None);
-        };
-        Ok(Some((row.get(0)?, row.get(1)?, row.get(2)?)))
-    }
-
-    fn insert_repo(&self, repo: &str, rev: &str, path: &str, deps: &[String]) -> Result<(), Error> {
-        let repo_name = Self::repo_name(repo, deps);
-
-        let mut stmt = self
-            .conn()
-            .prepare("INSERT INTO repos (repo, ref, path) VALUES (?, ?, ?)")?;
-        stmt.execute([repo_name.as_str(), rev, path])?;
-        Ok(())
-    }
-
-    /// Prepare a local repo for a local hook.
-    /// All local hooks with same additional dependencies, e.g. no dependencies,
-    /// are stored in the same directory (even they use different language).
-    pub fn prepare_local_repo(&self, hook: &Hook, deps: &[String]) -> Result<PathBuf, Error> {
-        const LOCAL_NAME: &str = "local";
-        const LOCAL_REV: &str = "1";
-
-        if hook.language.environment_dir().is_none() {
-            return Err(Error::LocalHookNoNeedEnv(hook.id.clone()));
-        }
-
-        let path = if let Some((_, _, path)) = self.get_repo(LOCAL_NAME, LOCAL_REV, deps)? {
-            path
-        } else {
-            let temp = tempfile::Builder::new()
-                .prefix("repo")
-                .keep(true)
-                .tempdir_in(&self.path)?;
-
-            let path = temp.path().to_string_lossy().to_string();
-            debug!(hook = hook.id, path, "Preparing local repo");
-            make_local_repo(LOCAL_NAME, temp.path())?;
-            self.insert_repo(LOCAL_NAME, LOCAL_REV, &path, deps)?;
-            path
-        };
-
-        Ok(PathBuf::from(path))
+        // TODO: add a readme
+        Ok(self)
     }
 
     /// Clone a remote repo into the store.
-    pub async fn prepare_remote_repo(
-        &self,
-        repo_config: &RemoteRepo,
-        deps: &[String],
-    ) -> Result<PathBuf, Error> {
-        if let Some((_, _, path)) = self.get_repo(
-            repo_config.repo.as_str(),
-            repo_config.rev.as_str(),
-            deps.as_ref(),
-        )? {
-            return Ok(PathBuf::from(path));
+    pub async fn clone_repo(&self, repo: &RemoteRepo) -> Result<PathBuf, Error> {
+        // Check if the repo is already cloned.
+        let target = self.repo_path(repo);
+        if target.join(".cloned_ok").try_exists()? {
+            return Ok(target);
         }
+
+        fs_err::tokio::create_dir_all(self.repos_dir()).await?;
 
         // Clone and checkout the repo.
-        let temp = tempfile::Builder::new()
-            .prefix("repo")
-            .keep(true)
-            .tempdir_in(&self.path)?;
-        let path = temp.path().to_string_lossy().to_string();
+        let temp = tempfile::tempdir_in(self.repos_dir())?;
+        debug!(
+            target = %temp.path().display(),
+            %repo,
+            "Cloning repo",
+        );
+        clone_repo(repo.repo.as_str(), &repo.rev, temp.path()).await?;
 
-        if deps.is_empty() {
-            debug!(
-                target = path,
-                repo = format!("{}@{}", repo_config.repo, repo_config.rev),
-                "Cloning repo",
-            );
-            clone_repo(repo_config.repo.as_str(), &repo_config.rev, temp.path()).await?;
-        } else {
-            // FIXME: Do not copy env dir.
-            // TODO: use hardlink?
-            // Optimization: This is an optimization from the Python pre-commit implementation.
-            // Copy already cloned base remote repo.
-            let (_, _, base_repo_path) = self
-                .get_repo(repo_config.repo.as_str(), repo_config.rev.as_str(), &[])?
-                .expect("base repo should be cloned before");
-            debug!(
-                source = base_repo_path,
-                target = path,
-                deps = deps.join(","),
-                "Preparing {}@{} by copying",
-                repo_config.repo,
-                repo_config.rev,
-            );
-            copy_dir_all(base_repo_path, &path)?;
-        }
+        // TODO: add windows retry
+        fs_err::tokio::remove_dir_all(&target).await.ok();
+        fs_err::tokio::rename(temp, &target).await?;
+        fs_err::tokio::write(target.join(".repo_source"), repo.to_string()).await?;
+        fs_err::tokio::write(target.join(".cloned_ok"), "").await?;
 
-        self.insert_repo(
-            repo_config.repo.as_str(),
-            repo_config.rev.as_str(),
-            &path,
-            deps,
-        )?;
-
-        Ok(PathBuf::from(path))
+        Ok(target)
     }
 
     /// Lock the store.
@@ -267,6 +108,40 @@ impl Store {
 
     pub async fn lock_async(&self) -> Result<LockedFile, std::io::Error> {
         LockedFile::acquire(self.path.join(".lock"), "store").await
+    }
+
+    /// Returns the path to the cloned repo.
+    fn repo_path(&self, repo: &RemoteRepo) -> PathBuf {
+        let mut hasher = SeaHasher::new();
+        repo.repo.hash(&mut hasher);
+        repo.rev.hash(&mut hasher);
+        let digest = to_hex(hasher.finish());
+        self.repos_dir().join(digest)
+    }
+
+    /// Returns the path to the installed hook environment.
+    pub fn hook_path(&self, hook: &Hook) -> Option<PathBuf> {
+        // Languages that can't install dependencies, no matter it's local or remote.
+        if !hook.language.supports_dependency() {
+            return None;
+        }
+        // Meta hooks never get installed.
+        if hook.is_meta() {
+            return None;
+        }
+
+        let mut hasher = SeaHasher::new();
+        hook.hash(&mut hasher);
+        let digest = to_hex(hasher.finish());
+        Some(self.hooks_dir().join(digest))
+    }
+
+    fn repos_dir(&self) -> PathBuf {
+        self.path.join("repos")
+    }
+
+    fn hooks_dir(&self) -> PathBuf {
+        self.path.join("hooks")
     }
 
     /// The path to the tool directory in the store.
@@ -292,20 +167,7 @@ impl ToolBucket {
     }
 }
 
-// TODO
-/// For local repo, creates a dummy package for each supported language, to make
-/// the installation code like `pip install .` work.
-fn make_local_repo(_repo: &str, path: &Path) -> Result<(), Error> {
-    fs_err::create_dir_all(path)?;
-    fs_err::File::create(path.join("__init__.py"))?;
-    fs_err::write(
-        path.join("setup.py"),
-        indoc::indoc! {r#"
-    from setuptools import setup
-
-    setup(name="pre-commit-placeholder-package", version="0.0.0")
-    "#},
-    )?;
-
-    Ok(())
+/// Convert a u64 to a hex string.
+fn to_hex(num: u64) -> String {
+    hex::encode(num.to_le_bytes())
 }


### PR DESCRIPTION
Restucture the `~/.cache/prefligit/` directory layout, moving from the `pre-commit` implementation.

- No longer use `sqlite` db
- Move cloned repositories into `HOME/repos`
- No longer create dummy packages for local repos
- Move installed hooks environment into `HOME/hooks`

