### PR TITLE
Implement pre-commit-hooks:end-of-file-fixer

### DIFF
--- a/src/builtin/pre_commit_hooks/fix_end_of_file.rs
+++ b/src/builtin/pre_commit_hooks/fix_end_of_file.rs
@@ -1,0 +1,58 @@
+use std::collections::HashMap;
+
+use anyhow::Result;
+use futures::StreamExt;
+
+use crate::hook::Hook;
+use crate::run::CONCURRENCY;
+
+pub(crate) async fn fix_end_of_file(
+    _hook: &Hook,
+    filenames: &[&String],
+    _env_vars: &HashMap<&'static str, String>,
+) -> Result<(i32, Vec<u8>)> {
+    let mut tasks = futures::stream::iter(filenames)
+        .map(async |filename| {
+            let content = fs_err::tokio::read(filename).await?;
+
+            // If the file is empty, do nothing.
+            if content.is_empty() {
+                return Ok((0, Vec::new()));
+            }
+
+            // Find the last non-newline character.
+            let last_char_pos = content.iter().rposition(|&c| c != b'\n');
+
+            let modified = if let Some(pos) = last_char_pos {
+                // The file has content other than newlines.
+                let new_content = [&content[..=pos], b"\n"].concat();
+                if new_content != content {
+                    fs_err::tokio::write(filename, &new_content).await?;
+                    anyhow::Ok((1, format!("Fixing {filename}\n").into_bytes()))
+                } else {
+                    anyhow::Ok((0, Vec::new()))
+                }
+            } else {
+                // The file consists only of newlines.
+                if content != b"\n" {
+                    fs_err::tokio::write(filename, b"\n").await?;
+                    anyhow::Ok((1, format!("Fixing {filename}\n").into_bytes()))
+                } else {
+                    anyhow::Ok((0, Vec::new()))
+                }
+            };
+            modified
+        })
+        .buffered(*CONCURRENCY);
+
+    let mut code = 0;
+    let mut output = Vec::new();
+
+    while let Some(result) = tasks.next().await {
+        let (c, o) = result?;
+        code |= c;
+        output.extend(o);
+    }
+
+    Ok((code, output))
+}

--- a/src/builtin/pre_commit_hooks/fix_end_of_file.rs
+++ b/src/builtin/pre_commit_hooks/fix_end_of_file.rs
@@ -20,8 +20,8 @@ pub(crate) async fn fix_end_of_file(
                 return Ok((0, Vec::new()));
             }
 
-            // Find the last non-newline character.
-            let last_char_pos = content.iter().rposition(|&c| c != b'\n');
+            // Find the last character that is not a newline char.
+            let last_char_pos = content.iter().rposition(|&c| c != b'\n' && c != b'\r');
 
             let modified = if let Some(pos) = last_char_pos {
                 // The file has content other than newlines.
@@ -33,7 +33,7 @@ pub(crate) async fn fix_end_of_file(
                     anyhow::Ok((0, Vec::new()))
                 }
             } else {
-                // The file consists only of newlines.
+                // The file consists only of newlines. Normalize to a single newline.
                 if content != b"\n" {
                     fs_err::tokio::write(filename, b"\n").await?;
                     anyhow::Ok((1, format!("Fixing {filename}\n").into_bytes()))

--- a/src/builtin/pre_commit_hooks/mod.rs
+++ b/src/builtin/pre_commit_hooks/mod.rs
@@ -7,11 +7,13 @@ use url::Url;
 use crate::hook::Hook;
 
 mod check_added_large_files;
+mod fix_end_of_file;
 mod fix_trailing_whitespace;
 
 pub(crate) enum Implemented {
     TrailingWhitespace,
     CheckAddedLargeFiles,
+    EndOfFileFixer,
 }
 
 impl FromStr for Implemented {
@@ -21,6 +23,7 @@ impl FromStr for Implemented {
         match s {
             "trailing-whitespace" => Ok(Self::TrailingWhitespace),
             "check-added-large-files" => Ok(Self::CheckAddedLargeFiles),
+            "end-of-file-fixer" => Ok(Self::EndOfFileFixer),
             _ => Err(()),
         }
     }
@@ -39,6 +42,9 @@ impl Implemented {
             }
             Self::CheckAddedLargeFiles => {
                 check_added_large_files::check_added_large_files(hook, filenames, env_vars).await
+            }
+            Self::EndOfFileFixer => {
+                fix_end_of_file::fix_end_of_file(hook, filenames, env_vars).await
             }
         }
     }

--- a/tests/builtin_hooks.rs
+++ b/tests/builtin_hooks.rs
@@ -33,13 +33,13 @@ fn end_of_file_fixer_hook() -> Result<()> {
     context.init_project();
     context.configure_git_author();
 
-    context.write_pre_commit_config(indoc::indoc! {r#"
+    context.write_pre_commit_config(indoc::indoc! {r"
         repos:
           - repo: https://github.com/pre-commit/pre-commit-hooks
             rev: v5.0.0
             hooks:
               - id: end-of-file-fixer
-    "#});
+    "});
 
     let cwd = context.workdir();
 

--- a/tests/builtin_hooks.rs
+++ b/tests/builtin_hooks.rs
@@ -1,10 +1,31 @@
+// FILE: ./tests/builtin_hooks.rs
 use anyhow::Result;
+use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
 use insta::assert_snapshot;
 
-use crate::common::{TestContext, cmd_snapshot};
+use crate::common::TestContext;
 
 mod common;
+
+/// A helper function to normalize the command output for snapshot testing.
+/// It sorts the lines that start with "Fixing " to make the output deterministic.
+fn normalize_output(output: &std::process::Output) -> String {
+    let stdout_str = String::from_utf8_lossy(&output.stdout);
+    let mut lines: Vec<&str> = stdout_str.lines().collect();
+
+    // Separate and sort the "Fixing..." lines from the rest of the output
+    let (mut fixing_lines, other_lines): (Vec<_>, Vec<_>) = lines
+        .drain(..)
+        .partition(|&line| line.trim().starts_with("Fixing "));
+    fixing_lines.sort_unstable();
+
+    // Reconstruct the output with the sorted lines at the end
+    let mut normalized_lines = other_lines;
+    normalized_lines.extend(fixing_lines);
+
+    normalized_lines.join("\n")
+}
 
 #[test]
 fn end_of_file_fixer_hook() -> Result<()> {
@@ -12,7 +33,6 @@ fn end_of_file_fixer_hook() -> Result<()> {
     context.init_project();
     context.configure_git_author();
 
-    // Set up the config to use the built-in end-of-file-fixer
     context.write_pre_commit_config(indoc::indoc! {r#"
         repos:
           - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -23,56 +43,56 @@ fn end_of_file_fixer_hook() -> Result<()> {
 
     let cwd = context.workdir();
 
-    // A file that is already correct (ends with one newline)
-    cwd.child("correct.txt").write_str("Hello World\n")?;
-    // A file with no trailing newline
+    // --- Create test files ---
+    cwd.child("correct_lf.txt").write_str("Hello World\n")?;
+    cwd.child("correct_crlf.txt").write_str("Hello World\r\n")?;
     cwd.child("no_newline.txt")
         .write_str("No trailing newline")?;
-    // A file with multiple trailing newlines
-    cwd.child("multiple_newlines.txt")
+    cwd.child("multiple_lf.txt")
         .write_str("Multiple newlines\n\n\n")?;
-    // An empty file
+    cwd.child("multiple_crlf.txt")
+        .write_str("Multiple newlines\r\n\r\n")?;
     cwd.child("empty.txt").touch()?;
-    // A file containing only newlines
     cwd.child("only_newlines.txt").write_str("\n\n")?;
-    // Stage all files
+    cwd.child("only_win_newlines.txt").write_str("\r\n\r\n")?;
+
     context.git_add(".");
 
     // First run: hooks should fail and fix the files
-    cmd_snapshot!(context.filters(), context.run(), @r###"
-    success: false
-    exit_code: 1
-    ----- stdout -----
+    let first_run_output = context.run().assert().failure().get_output().clone();
+    let normalized_first_run = normalize_output(&first_run_output);
+
+    // Snapshot the normalized, deterministic output
+    assert_snapshot!(normalized_first_run, @r###"
     fix end of files.........................................................Failed
     - hook id: end-of-file-fixer
     - exit code: 1
     - files were modified by this hook
+      Fixing correct_crlf.txt
+      Fixing multiple_crlf.txt
+      Fixing multiple_lf.txt
       Fixing no_newline.txt
-      Fixing multiple_newlines.txt
       Fixing only_newlines.txt
-
-    ----- stderr -----
+      Fixing only_win_newlines.txt
     "###);
 
     // Assert that the files have been corrected
-    assert_snapshot!(context.read("correct.txt"), @"Hello World\n");
+    assert_snapshot!(context.read("correct_lf.txt"), @"Hello World\n");
+    assert_snapshot!(context.read("correct_crlf.txt"), @"Hello World\n");
     assert_snapshot!(context.read("no_newline.txt"), @"No trailing newline\n");
-    assert_snapshot!(context.read("multiple_newlines.txt"), @"Multiple newlines\n");
+    assert_snapshot!(context.read("multiple_lf.txt"), @"Multiple newlines\n");
+    assert_snapshot!(context.read("multiple_crlf.txt"), @"Multiple newlines\n");
     assert_snapshot!(context.read("empty.txt"), @"");
     assert_snapshot!(context.read("only_newlines.txt"), @"\n");
+    assert_snapshot!(context.read("only_win_newlines.txt"), @"\n");
 
-    // Stage the fixes
     context.git_add(".");
 
-    // Second run: hooks should now pass
-    cmd_snapshot!(context.filters(), context.run(), @r###"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    fix end of files.........................................................Passed
+    // Second run: hooks should now pass. The output will be stable.
+    let second_run_output = context.run().assert().success().get_output().clone();
+    let normalized_second_run = normalize_output(&second_run_output);
 
-    ----- stderr -----
-    "###);
+    assert_snapshot!(normalized_second_run, @"fix end of files.........................................................Passed");
 
     Ok(())
 }

--- a/tests/builtin_hooks.rs
+++ b/tests/builtin_hooks.rs
@@ -1,0 +1,78 @@
+use anyhow::Result;
+use assert_fs::prelude::*;
+use insta::assert_snapshot;
+
+use crate::common::{TestContext, cmd_snapshot};
+
+mod common;
+
+#[test]
+fn end_of_file_fixer_hook() -> Result<()> {
+    let context = TestContext::new();
+    context.init_project();
+    context.configure_git_author();
+
+    // Set up the config to use the built-in end-of-file-fixer
+    context.write_pre_commit_config(indoc::indoc! {r#"
+        repos:
+          - repo: https://github.com/pre-commit/pre-commit-hooks
+            rev: v5.0.0
+            hooks:
+              - id: end-of-file-fixer
+    "#});
+
+    let cwd = context.workdir();
+
+    // A file that is already correct (ends with one newline)
+    cwd.child("correct.txt").write_str("Hello World\n")?;
+    // A file with no trailing newline
+    cwd.child("no_newline.txt")
+        .write_str("No trailing newline")?;
+    // A file with multiple trailing newlines
+    cwd.child("multiple_newlines.txt")
+        .write_str("Multiple newlines\n\n\n")?;
+    // An empty file
+    cwd.child("empty.txt").touch()?;
+    // A file containing only newlines
+    cwd.child("only_newlines.txt").write_str("\n\n")?;
+    // Stage all files
+    context.git_add(".");
+
+    // First run: hooks should fail and fix the files
+    cmd_snapshot!(context.filters(), context.run(), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    fix end of files.........................................................Failed
+    - hook id: end-of-file-fixer
+    - exit code: 1
+    - files were modified by this hook
+      Fixing no_newline.txt
+      Fixing multiple_newlines.txt
+      Fixing only_newlines.txt
+
+    ----- stderr -----
+    "###);
+
+    // Assert that the files have been corrected
+    assert_snapshot!(context.read("correct.txt"), @"Hello World\n");
+    assert_snapshot!(context.read("no_newline.txt"), @"No trailing newline\n");
+    assert_snapshot!(context.read("multiple_newlines.txt"), @"Multiple newlines\n");
+    assert_snapshot!(context.read("empty.txt"), @"");
+    assert_snapshot!(context.read("only_newlines.txt"), @"\n");
+
+    // Stage the fixes
+    context.git_add(".");
+
+    // Second run: hooks should now pass
+    cmd_snapshot!(context.filters(), context.run(), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    fix end of files.........................................................Passed
+
+    ----- stderr -----
+    "###);
+
+    Ok(())
+}


### PR DESCRIPTION
Reproduces the behavior of [pre-commit end-of-file-fixer](https://github.com/pre-commit/pre-commit-hooks/blob/main/pre_commit_hooks/end_of_file_fixer.py)